### PR TITLE
finished create category

### DIFF
--- a/TabloidMVC/Controllers/CategoryController.cs
+++ b/TabloidMVC/Controllers/CategoryController.cs
@@ -2,7 +2,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualBasic;
+using System;
 using System.Security.Claims;
+using TabloidMVC.Models;
 using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
 
@@ -18,16 +20,39 @@ namespace TabloidMVC.Controllers
             _categoryRepository = categoryRepository;
         }
 
-
+        // GET: CategoryController
         public IActionResult Index()
         {
             var posts = _categoryRepository.GetAll();
             return View(posts);
         }
 
+        // GET: CategoryController/Details/5
         public ActionResult Details(int id)
         {
             return View();
+        }
+
+        // GET: CategoryController/Create
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: CategoryController/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(Category category)
+        {
+            try
+            {
+                _categoryRepository.AddCategory(category);
+                return RedirectToAction("Index");
+            }
+            catch (Exception ex)
+            {
+                return View(category);
+            }
         }
     }
 }

--- a/TabloidMVC/Repositories/CategoryRepository.cs
+++ b/TabloidMVC/Repositories/CategoryRepository.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using TabloidMVC.Models;
 
@@ -31,6 +33,25 @@ namespace TabloidMVC.Repositories
                     reader.Close();
 
                     return categories;
+                }
+            }
+        }
+
+        public void AddCategory(Category category)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                    INSERT INTO Category (Name)
+                    OUTPUT INSERTED.Id
+                    VALUES (@name)";
+                    cmd.Parameters.AddWithValue("@name", category.Name);
+
+                    int newlyCreatedId = (int)cmd.ExecuteScalar();
+                    category.Id = newlyCreatedId;
                 }
             }
         }

--- a/TabloidMVC/Repositories/ICategoryRepository.cs
+++ b/TabloidMVC/Repositories/ICategoryRepository.cs
@@ -6,5 +6,6 @@ namespace TabloidMVC.Repositories
     public interface ICategoryRepository
     {
         List<Category> GetAll();
+        void AddCategory(Category category);
     }
 }

--- a/TabloidMVC/Views/Category/Create.cshtml
+++ b/TabloidMVC/Views/Category/Create.cshtml
@@ -1,0 +1,38 @@
+﻿@model TabloidMVC.Models.Category
+
+@{
+    ViewData["Title"] = "Create";
+}
+
+<h1>Create</h1>
+
+<h4>Category</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Create">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Id" class="control-label"></label>
+                <input asp-for="Id" class="form-control" />
+                <span asp-validation-for="Id" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Create" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}


### PR DESCRIPTION
As an admin I would like to be able to create a new category so that I can give authors the ability to better classify their posts.

Given an admin is on the Category list page
When they select the Create Category button
Then they should be directed to a form in which they can enter a new category name

Given an admin has entered a Category name
When they click the Save button
Then a new category should be saved to the database
And the admin should be directed to the Category list page

NOTE: For the time being it is acceptable to treat all users as admin users. There is a future story about enforcing user permissions.